### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,7 +49,7 @@ class CreateCategoriesTable extends Migration {
         Schema::create('categories', function(Blueprint $table) {
             $table->increments('id');
             $table->string('title');
-            $table->timestamps();
+            $table->nullableTimestamps();
 
             NestedSet::columns($table);
         });


### PR DESCRIPTION
Either nullableTimestamps(), or add created, updated timestamps to createRoot.
Otherwise liable to throw:

```
[Illuminate\Database\QueryException]                                         
  SQLSTATE[23000]: Integrity constraint violation: 19 categories.created_at m  
  ay not be NULL
```

disregard if it's just my database setup (sqlite)
