### PR TITLE
Fix missing $connection parameter for newFromBuilder method

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -756,10 +756,10 @@ class Node extends Eloquent {
     /**
      * {@inheritdoc}
      */
-    public function newFromBuilder($attributes = array())
+    public function newFromBuilder($attributes = array(), $connection = null)
     {
         /** @var Node $instance */
-        $instance = parent::newFromBuilder($attributes);
+        $instance = parent::newFromBuilder($attributes, $connection);
 
         $instance->clearAction();
 


### PR DESCRIPTION
Caused by https://github.com/laravel/framework/commit/e777e417c8a43af1675e08742a2a0f77bf188621 