### PR TITLE
Fix creation as root

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -757,6 +757,8 @@ trait NodeTrait
 
         if ($parent) {
             $instance->appendToNode($parent);
+        } else {
+            $instance->actionRoot();
         }
 
         $instance->save();

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -755,11 +755,13 @@ trait NodeTrait
 
         $instance = new static($attributes);
 
-        if ($parent) {
-            $instance->appendToNode($parent);
+        if (is_null($parent) || !$parent->exists) {
+            $instance->makeRoot();
         } else {
-            $instance->actionRoot();
+            $instance->appendToNode($parent);
         }
+
+        $instance->callPendingAction();
 
         $instance->save();
 


### PR DESCRIPTION
This is necessary to avoid database constraint errors since the following code will NOT run when creating a new model (when creating a model using the `create` method, `static::creating`, `static::created`, `static::saving` and `static::saved` are not registered yet when defined in the `boot` method of a model).

```php
    public static function bootNodeTrait()
    {
        static::saving(function (self $model) {
            $model->getConnection()->beginTransaction();

            return $model->callPendingAction();
        });
    }
``` 
