### PR TITLE
Added checks on saving and saved events

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -46,13 +46,17 @@ trait NodeTrait
     public static function bootNodeTrait()
     {
         static::saving(function ($model) {
-            $model->getConnection()->beginTransaction();
+            if ($model->isDirty()) {
+                $model->getConnection()->beginTransaction();
+            }
 
             return $model->callPendingAction();
         });
 
         static::saved(function ($model) {
-            $model->getConnection()->commit();
+            if ($model->isDirty()) {
+                $model->getConnection()->commit();
+            }
         });
 
         static::deleting(function ($model) {


### PR DESCRIPTION
Added a check to open and close the transaction only if the model is dirty.

Without the check, the transaction is opened on the saving event even if there's nothing to save. So, if the model has not changed, the saved event won't be called and the transaction will never be committed.

This could work anyway for the model that implements NodeTrait, but it prevents subsequent updates on other models, because the transaction is then automatically rollbacked.

This is probably related to the #129 bug.
