### PR TITLE
Target $original in `NodeTrait::dirtyBounds` rather than $attributes

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -1138,7 +1138,9 @@ trait NodeTrait
      */
     protected function dirtyBounds()
     {
-        return $this->setLft(null)->setRgt(null);
+        $this->original[$this->getLftName()] = null;
+        $this->original[$this->getRgtName()] = null;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Modifying the $attributes array would cause it to attempt to save null for the lft and rgt values if none of the queued actions modified them.
Relates to issue #147