### PR TITLE
Feature: Decrease number of queries used by nested set

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -21,7 +21,7 @@ class Collection extends BaseCollection
 
         /** @var Node $node */
         foreach ($this->items as $node) {
-            if ( ! isset($node->parent)) {
+            if (! $node->parent_id) {
                 $node->setRelation('parent', null);
             }
 


### PR DESCRIPTION
Feature: Decrease number of queries used by nested set by using the parent_id field instead of the paren() relation.

Why are you using the parent() function to check if the node has a parent? In the current situation it will automatically use Eloquent to query the database. That isn't necessary, because the parent_id is already there, so why do an extra DB call?