### PR TITLE
Add isSelfOrDescendantOf and isSelfOrAncestorOf helpers

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -1007,6 +1007,19 @@ trait NodeTrait
     }
 
     /**
+     * Get whether a node is itself or a descendant of other node.
+     *
+     * @param self $other
+     *
+     * @return bool
+     */
+    public function isSelfOrDescendantOf(self $other)
+    {
+        return $this->getLft() >= $other->getLft() &&
+               $this->getLft() < $other->getRgt();
+    }
+
+    /**
      * Get whether the node is immediate children of other node.
      *
      * @param self $other
@@ -1040,6 +1053,18 @@ trait NodeTrait
     public function isAncestorOf(self $other)
     {
         return $other->isDescendantOf($this);
+    }
+
+    /**
+     * Get whether the node is itself or an ancestor of other node, including immediate parent.
+     *
+     * @param self $other
+     *
+     * @return bool
+     */
+    public function isSelfOrAncestorOf(self $other)
+    {
+        return $other->isSelfOrDescendantOf($this);
     }
 
     /**


### PR DESCRIPTION
Hi, thanks for the great library. I am trying to migrate from another nested set library and there were helper methods that I used frequently in my projects. I added the helper methods isSelfOrDescendantOf and isSelfOrAncestorOf to check if the given node is itself or a descendant or an ancestor of the other node.