### PR TITLE
Refresh node after creating children

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -778,6 +778,8 @@ trait NodeTrait
             $child->setRelation('parent', $instance);
         }
 
+        $instance->refreshNode();
+
         return $instance->setRelation('children', $relation);
     }
 


### PR DESCRIPTION
Noticed that the root node's _rgt doesn't cover all of the descendants but refreshing node after creating children solves this issue.