### PR TITLE
Fixed problem with incorrect table name in self-relations

### DIFF
--- a/src/AncestorsRelation.php
+++ b/src/AncestorsRelation.php
@@ -63,6 +63,7 @@ class AncestorsRelation extends Relation
         $table = $query->getModel()->getTable();
 
         $query->from($table.' as '.$hash = $this->getRelationSubSelectHash());
+		$query->getModel()->setTable($hash);
 
         $grammar = $query->getQuery()->getGrammar();
 

--- a/src/DescendantsRelation.php
+++ b/src/DescendantsRelation.php
@@ -51,6 +51,7 @@ class DescendantsRelation extends Relation
         $table = $query->getModel()->getTable();
 
         $query->from($table.' as '.$hash = $this->getRelationCountHash());
+		$query->getModel()->setTable($hash);
 
         $grammar = $query->getQuery()->getGrammar();
 


### PR DESCRIPTION
Problem was that when you called whereHas, orWhereHas on descendants or ancestors, the incorrect table name was passed, resulting in the subquery using original table name, instead of hashed one.