### PR TITLE
Fixed documentation to have getDirty method to avoid breaking of tree.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -126,7 +126,8 @@ $parent->appendNode($node);
 $parent->children()->create($attributes);
 
 // #5 Using node's parent relationship
-$node->parent()->associate($parent)->save();
+//Here using of getDirty method is important to maintain correct values of _lft and _rgt.
+$node->parent()->associate($parent)->getDirty()->save();
 
 // #6 Using the parent attribute
 $node->parent_id = $parent->id;


### PR DESCRIPTION
Use of `getDirty()` is important when using `associate()` method of `belongsTo` relationship. As `associate()` will update the `parent` column with corresponding `parent id` but it will not set proper values of `_lft` and `_rgt` when its child is added. Further more, This creates the problem in deleting the node. If a `parent` node is deleted then their `children` will not be deleted due to incorrect bounds of the parent node.
 In addition to this if we check `descendants` it will not have the new node due to incorrect bounds. So to fix all the above problems we need to use `getDirty()` after `associating the parent node`. 