### PR TITLE
Add helper method to obtain children with associated parent.

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -242,6 +242,17 @@ trait NodeTrait
     }
 
     /**
+     * Children with parent associated with it.
+     * @return mixed
+     */
+    public function childrenAndSelf(){
+        $childrenAndSelf = $this->children;
+        $childrenAndSelf->prepend($this);
+        return $childrenAndSelf;
+    }
+
+
+    /**
      * Get query for descendants of the node.
      *
      * @return DescendantsRelation


### PR DESCRIPTION
Sometimes it is important to have children with associated parent (In case of filters) . So there should be a helper method which can return children with associated parent.