### PR TITLE
Fix query builder: get primary key from model

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -721,12 +721,13 @@ class QueryBuilder extends Builder
 
         $waFirst = $this->query->getGrammar()->wrapTable($firstAlias);
         $waSecond = $this->query->getGrammar()->wrapTable($secondAlias);
+        $pk = $this->model->getKeyName();
 
         $query = $this->model
             ->newNestedSetQuery($firstAlias)
             ->toBase()
             ->from($this->query->raw("{$table} as {$waFirst}, {$table} {$waSecond}"))
-            ->whereRaw("{$waFirst}.id < {$waSecond}.id")
+            ->whereRaw("{$waFirst}.{$pk} < {$waSecond}.{$pk}")
             ->whereNested(function (BaseQueryBuilder $inner) use ($waFirst, $waSecond) {
                 list($lft, $rgt) = $this->wrappedColumns();
 


### PR DESCRIPTION
Using the primary key name as set in the model instead of assuming it's just `id`. 