### PR TITLE
Remove hardcoded refs to "id" as PK

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -715,6 +715,7 @@ class QueryBuilder extends Builder
     protected function getDuplicatesQuery()
     {
         $table = $this->wrappedTable();
+        $keyName = $this->wrappedKey();
 
         $firstAlias = 'c1';
         $secondAlias = 'c2';
@@ -726,7 +727,7 @@ class QueryBuilder extends Builder
             ->newNestedSetQuery($firstAlias)
             ->toBase()
             ->from($this->query->raw("{$table} as {$waFirst}, {$table} {$waSecond}"))
-            ->whereRaw("{$waFirst}.id < {$waSecond}.id")
+            ->whereRaw("{$waFirst}.{$keyName} < {$waSecond}.{$keyName}")
             ->whereNested(function (BaseQueryBuilder $inner) use ($waFirst, $waSecond) {
                 list($lft, $rgt) = $this->wrappedColumns();
 


### PR DESCRIPTION
@getDuplicatesQuery used "id" directly as primary key for the model. Changed to "{keyName}" notation. :-)