### PR TITLE
Fix '0' PK for root nodes

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -64,7 +64,7 @@ class Collection extends BaseCollection
 
         /** @var Model|NodeTrait $node */
         foreach ($this->items as $node) {
-            if ($node->getParentId() == $root) {
+            if ($node->getParentId() === $root) {
                 $items[] = $node;
             }
         }

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -144,6 +144,22 @@ trait NodeTrait
     }
 
     /**
+     * Get the casts array.
+     *
+     * @return array
+     */
+    public function getCasts()
+    {
+        $casts = parent::getCasts();
+
+        if ($this->getIncrementing()) {
+            return array_merge([$this->getParentIdName() => $this->getKeyType()], $casts);
+        }
+
+        return $casts;
+    }
+
+    /**
      * Get the lower bound.
      *
      * @return int

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -153,7 +153,9 @@ trait NodeTrait
         $casts = parent::getCasts();
 
         if ($this->getIncrementing()) {
-            return array_merge([$this->getParentIdName() => $this->getKeyType()], $casts);
+            $type = method_exists($this, 'getKeyType') ? $this->getKeyType() : 'int';
+
+            return array_merge([$this->getParentIdName() => $type], $casts);
         }
 
         return $casts;


### PR DESCRIPTION
In our project we have main tree root saved manually under **0** index. And when we try to build a tree, this node disappears. This small pr fixes such problem.