### PR TITLE
Apply withoutGlobalScope for withDepth

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -409,6 +409,7 @@ class QueryBuilder extends Builder
 
         $query = $this->model
             ->newScopedQuery('_d')
+            ->withoutGlobalScopes($this->removedScopes)
             ->toBase()
             ->selectRaw('count(1) - 1')
             ->from($this->model->getTable().' as '.$alias)


### PR DESCRIPTION
I want to use whitoutGlobalScope for withDepth, the query of withDepth have the globalScope. 