### PR TITLE
Adding rebuild fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kalnoy/nestedset",
-    "description": "Nested Set Model for Laravel 5.7 and up",
+    "description": "Nested Set Model for Laravel 6.0 and up",
     "keywords": ["laravel", "nested sets", "nsm", "database", "hierarchy"],
     "license": "MIT",
 
@@ -13,9 +13,9 @@
 
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "~5.7.0|~5.8.0",
-        "illuminate/database": "~5.7.0|~5.8.0",
-        "illuminate/events": "~5.7.0|~5.8.0"
+        "illuminate/support": "^5.7.0",
+        "illuminate/database": "^5.7.0",
+        "illuminate/events": "^5.7.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
 
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "^5.7.0",
-        "illuminate/database": "^5.7.0",
-        "illuminate/events": "^5.7.0"
+        "illuminate/support": "~5.7.0|~5.8.0|~6.0.0",
+        "illuminate/database": "~5.7.0|~5.8.0|~6.0.0",
+        "illuminate/events": "~5.7.0|~5.8.0|~6.0.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kalnoy/nestedset",
+    "name": "vankizmann/nestedset",
     "description": "Nested Set Model for Laravel 4-5",
     "keywords": ["laravel", "nested sets", "nsm", "database", "hierarchy"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "vankizmann/nestedset",
+    "name": "kalnoy/nestedset",
     "description": "Nested Set Model for Laravel 4-5",
     "keywords": ["laravel", "nested sets", "nsm", "database", "hierarchy"],
     "license": "MIT",

--- a/src/NestedSet.php
+++ b/src/NestedSet.php
@@ -22,6 +22,11 @@ class NestedSet
     const PARENT_ID = 'parent_id';
 
     /**
+     * The names of fields to rebuild.
+     */
+    const REBUILD_FIELDS = [];
+
+    /**
      * Insert direction.
      */
     const BEFORE = 1;

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Arr;
 use LogicException;
 
 trait NodeTrait
@@ -752,7 +753,7 @@ trait NodeTrait
      */
     public static function create(array $attributes = [], self $parent = null)
     {
-        $children = array_pull($attributes, 'children');
+        $children = Arr::pull($attributes, 'children');
 
         $instance = new static($attributes);
 

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -867,6 +867,16 @@ trait NodeTrait
     }
 
     /**
+     * Get the rebuild fields.
+     *
+     * @return  string
+     */
+    public function getRebuildFields()
+    {
+        return NestedSet::REBUILD_FIELDS;
+    }
+
+    /**
      * Get the value of the model's lft key.
      *
      * @return  integer

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1052,7 +1052,11 @@ class QueryBuilder extends Builder
                 unset($existing[$key]);
             }
 
-            $model->fill(Arr::except($itemData, 'children'))->save();
+            $fields = Arr::merge($model->getRebuildFields(), [
+                $model->getLftName(), $model->getRgtName(), $model->getParentIdName()
+            ]);
+
+            $model->fill(Arr::except(Arr::only($itemData, $fields), 'children'))->save();
 
             $dictionary[$parentId][] = $model;
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -1052,7 +1052,7 @@ class QueryBuilder extends Builder
                 unset($existing[$key]);
             }
 
-            $fields = Arr::merge($model->getRebuildFields(), [
+            $fields = array_merge($model->getRebuildFields(), [
                 $model->getLftName(), $model->getRgtName(), $model->getParentIdName()
             ]);
 


### PR DESCRIPTION
Adding fields wich will be used in tree rebuilding including the default ones (_lft,_rgt, parent_id).

**Example:**
Rebuilding menu with full dataset (title, route, state etc.) will update the whole model. With custom rebuild fields you can only update route without affecting the other columns.