### PR TITLE
[WIP] Fix custom parent_id column name not working

### DIFF
--- a/phpunit.php
+++ b/phpunit.php
@@ -9,3 +9,4 @@ $capsule->bootEloquent();
 $capsule->setAsGlobal();
 
 include __DIR__.'/tests/models/Category.php';
+include __DIR__.'/tests/models/CategoryWithCustomParent.php';

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -20,6 +20,15 @@ class NodeTest extends PHPUnit_Framework_TestCase
             NestedSet::columns($table);
         });
 
+        $schema->create('categories_with_custom_parent', function (\Illuminate\Database\Schema\Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->unsignedInteger('parent_category_id')->nullable();
+            $table->unsignedInteger('_lft')->default(0);
+            $table->unsignedInteger('_rgt')->default(0);
+            $table->softDeletes();
+        });
+
         Capsule::enableQueryLog();
     }
 
@@ -28,6 +37,10 @@ class NodeTest extends PHPUnit_Framework_TestCase
         $data = include __DIR__.'/data/categories.php';
 
         Capsule::table('categories')->insert($data);
+
+        $data = include __DIR__.'/data/categories_with_custom_parent.php';
+
+        Capsule::table('categories_with_custom_parent')->insert($data);
 
         Capsule::flushQueryLog();
 
@@ -39,6 +52,7 @@ class NodeTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         Capsule::table('categories')->truncate();
+        Capsule::table('categories_with_custom_parent')->truncate();
     }
 
     // public static function tearDownAfterClass()
@@ -335,6 +349,26 @@ class NodeTest extends PHPUnit_Framework_TestCase
         $node->refreshNode();
 
         $this->assertEquals(null, $node->parent_id);
+        $this->assertTrue($node->isRoot());
+    }
+
+    public function testParentIdCustomAttributeAccessorAppendsNode()
+    {
+        $node = new CategoryWithCustomParent([
+            'name' => 'lg',
+            'parent_category_id' => 5,
+        ]);
+        $node->save();
+
+        $this->assertEquals(5, $node->parent_category_id);
+        $this->assertEquals(5, $node->getParentId());
+
+        $node->parent_category_id = null;
+        $node->save();
+
+        $node->refreshNode();
+
+        $this->assertEquals(null, $node->parent_category_id);
         $this->assertTrue($node->isRoot());
     }
 

--- a/tests/data/categories_with_custom_parent.php
+++ b/tests/data/categories_with_custom_parent.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    ['id' => 1, 'name' => 'store', '_lft' => 1, '_rgt' => 20, 'parent_category_id' => null],
+        ['id' => 2, 'name' => 'notebooks', '_lft' => 2, '_rgt' => 7, 'parent_category_id' => 1],
+            ['id' => 3, 'name' => 'apple', '_lft' => 3, '_rgt' => 4, 'parent_category_id' => 2],
+            ['id' => 4, 'name' => 'lenovo', '_lft' => 5, '_rgt' => 6, 'parent_category_id' => 2],
+        ['id' => 5, 'name' => 'mobile', '_lft' => 8, '_rgt' => 19, 'parent_category_id' => 1],
+            ['id' => 6, 'name' => 'nokia', '_lft' => 9, '_rgt' => 10, 'parent_category_id' => 5],
+            ['id' => 7, 'name' => 'samsung', '_lft' => 11, '_rgt' => 14, 'parent_category_id' => 5],
+                ['id' => 8, 'name' => 'galaxy', '_lft' => 12, '_rgt' => 13, 'parent_category_id' => 7],
+            ['id' => 9, 'name' => 'sony', '_lft' => 15, '_rgt' => 16, 'parent_category_id' => 5],
+            ['id' => 10, 'name' => 'lenovo', '_lft' => 17, '_rgt' => 18, 'parent_category_id' => 5],
+    ['id' => 11, 'name' => 'store_2', '_lft' => 21, '_rgt' => 22, 'parent_category_id' => null],
+];

--- a/tests/models/CategoryWithCustomParent.php
+++ b/tests/models/CategoryWithCustomParent.php
@@ -1,0 +1,30 @@
+<?php
+
+use \Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Kalnoy\Nestedset\NodeTrait;
+
+class CategoryWithCustomParent extends Model
+{
+    use SoftDeletes;
+    use NodeTrait;
+
+    protected $table = 'categories_with_custom_parent';
+
+    protected $fillable = [
+        'name',
+        'parent_category_id',
+    ];
+
+    public $timestamps = false;
+
+    public static function resetActionsPerformed()
+    {
+        static::$actionsPerformed = 0;
+    }
+
+    public function getParentIdName()
+    {
+        return 'parent_category_id';
+    }
+}


### PR DESCRIPTION
Don't merge, it's just showing that custom `getParentIdName` will break creation of the model.

```php
public function getParentIdName()
{
    return 'parent_category_id';
}
```

It's described in #336