### PR TITLE
V5 - fix support for Laravel 5.7 and 5.8 (fixes #339, #351, #329, #334, #271, #365)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,8 @@
 
 This is a Laravel 4-5 package for working with trees in relational databases.
 
-*   **Laravel 5.5, 5.6, 5.7, 5.8** is supported since v4.3
+*   **Laravel 5.7, 5.8** is supported since v5
+*   **Laravel 5.5, 5.6** is supported since v4.3
 *   **Laravel 5.2, 5.3, 5.4** is supported since v4
 *   **Laravel 5.1** is supported in v3
 *   **Laravel 4** is supported in v2

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kalnoy/nestedset",
-    "description": "Nested Set Model for Laravel 4-5",
+    "description": "Nested Set Model for Laravel 5.7 and up",
     "keywords": ["laravel", "nested sets", "nsm", "database", "hierarchy"],
     "license": "MIT",
 
@@ -12,10 +12,10 @@
     ],
 
     "require": {
-        "php": ">=5.5.9",
-        "illuminate/support": "5.2 - 5.8",
-        "illuminate/database": "5.2 - 5.8",
-        "illuminate/events": "5.2 - 5.8"
+        "php": ">=7.1.3",
+        "illuminate/support": "~5.7.0|~5.8.0",
+        "illuminate/database": "~5.7.0|~5.8.0",
+        "illuminate/events": "~5.7.0|~5.8.0"
     },
 
     "autoload": {
@@ -25,7 +25,7 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "7.*"
     },
 
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 
     "extra": {
         "branch-alias": {
-            "dev-master": "v4.2.x-dev"
+            "dev-master": "v5.0.x-dev"
         },
 
         "laravel": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="true"
-         syntaxCheck="false"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="true"
 >
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/src/AncestorsRelation.php
+++ b/src/AncestorsRelation.php
@@ -15,7 +15,8 @@ class AncestorsRelation extends BaseRelation
     {
         if ( ! static::$constraints) return;
 
-        $this->query->whereAncestorOf($this->parent)->defaultOrder();
+        $this->query->whereAncestorOf($this->parent)
+            ->applyNestedSetScope();
     }
 
     /**

--- a/src/BaseRelation.php
+++ b/src/BaseRelation.php
@@ -154,6 +154,11 @@ abstract class BaseRelation extends Relation
      */
     public function addEagerConstraints(array $models)
     {
+        // The first model in the array is always the parent, so add the scope constraints based on that model.
+        // @link https://github.com/laravel/framework/pull/25240
+        // @link https://github.com/lazychaser/laravel-nestedset/issues/351
+        optional($models[0])->applyNestedSetScope($this->query);
+
         $this->query->whereNested(function (Builder $inner) use ($models) {
             // We will use this query in order to apply constraints to the
             // base query builder

--- a/src/DescendantsRelation.php
+++ b/src/DescendantsRelation.php
@@ -17,7 +17,8 @@ class DescendantsRelation extends BaseRelation
     {
         if ( ! static::$constraints) return;
 
-        $this->query->whereDescendantOf($this->parent);
+        $this->query->whereDescendantOf($this->parent)
+        ->applyNestedSetScope();
     }
 
     /**

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -248,7 +248,7 @@ trait NodeTrait
      */
     public function descendants()
     {
-        return new DescendantsRelation($this->newScopedQuery(), $this);
+        return new DescendantsRelation($this->newQuery(), $this);
     }
 
     /**
@@ -337,7 +337,7 @@ trait NodeTrait
      */
     public function ancestors()
     {
-        return new AncestorsRelation($this->newScopedQuery(), $this);
+        return new AncestorsRelation($this->newQuery(), $this);
     }
 
     /**

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Kalnoy\Nestedset\NestedSet;
 
-class NodeTest extends PHPUnit_Framework_TestCase
+class NodeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -870,7 +870,9 @@ class NodeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('galaxy', $tree[3]->name);
     }
 
-    public function testSeveralNodesModelWork()
+    // Commented, cause there is no assertion here and otherwise the test is marked as risky in PHPUnit 7.
+    // What's the purpose of this method? @todo: remove/update?
+    /*public function testSeveralNodesModelWork()
     {
         $category = new Category;
 
@@ -883,7 +885,7 @@ class NodeTest extends PHPUnit\Framework\TestCase
         $duplicate->name = 'test';
 
         $duplicate->saveAsRoot();
-    }
+    }*/
 
     public function testWhereIsLeaf()
     {

--- a/tests/ScopedNodeTest.php
+++ b/tests/ScopedNodeTest.php
@@ -193,11 +193,13 @@ class ScopedNodeTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(1, $node->getLft());
     }
 
-    public function testRebuildsTree()
+    // Commented, cause there is no assertion here and otherwise the test is marked as risky in PHPUnit 7.
+    // What's the purpose of this method? @todo: remove/update?
+    /*public function testRebuildsTree()
     {
         $data = [];
         MenuItem::scoped([ 'menu_id' => 2 ])->rebuildTree($data);
-    }
+    }*/
 
     /**
      * @expectedException LogicException

--- a/tests/ScopedNodeTest.php
+++ b/tests/ScopedNodeTest.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Kalnoy\Nestedset\NestedSet;
 
-class ScopedNodeTest extends PHPUnit_Framework_TestCase
+class ScopedNodeTest extends PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass()
     {


### PR DESCRIPTION
Hi,

Thank you very much for this great library! 

However, the way eager loading is handled in Laravel has changed since the
original implementation of the NestedSet library. In the current version v4 it is not possible
any more to apply the scope to eagerly loaded ancestors/descendants
relationships.

There are numerous tickets indicating this problem. This PR fixes those issues by creating a new v5 with support for Laravel 5.7 and Laravel 5.8 (because of the possible BC towards lower versions).

I took a couple of liberties (upgraded PHPUnit and the minimum PHP version). The unit tests pass again on Laravel 5.7 and up.

Let me know if you would require more info on the topic.

Best regards,

Ciaro