### PR TITLE
Set columns to unsignedBigInteger & Add foreign key to parent id

### DIFF
--- a/src/NestedSet.php
+++ b/src/NestedSet.php
@@ -36,13 +36,14 @@ class NestedSet
      *
      * @param \Illuminate\Database\Schema\Blueprint $table
      */
-    public static function columns(Blueprint $table)
+    public static function columns(Blueprint $table, string $id = 'id')
     {
-        $table->unsignedInteger(self::LFT)->default(0);
-        $table->unsignedInteger(self::RGT)->default(0);
-        $table->unsignedInteger(self::PARENT_ID)->nullable();
+        $table->unsignedBigInteger(self::LFT)->default(0);
+        $table->unsignedBigInteger(self::RGT)->default(0);
+        $table->unsignedBigInteger(self::PARENT_ID)->nullable();
 
         $table->index(static::getDefaultColumns());
+        $table->foreign(self::PARENT_ID)->references($id)->on($table->getTable())->onDelete('cascade');
     }
 
     /**

--- a/src/NestedSet.php
+++ b/src/NestedSet.php
@@ -35,15 +35,16 @@ class NestedSet
      * Add default nested set columns to the table. Also create an index.
      *
      * @param \Illuminate\Database\Schema\Blueprint $table
+     * @param string $idColumn
      */
-    public static function columns(Blueprint $table, string $id = 'id')
+    public static function columns(Blueprint $table, string $idColumn = 'id')
     {
         $table->unsignedBigInteger(self::LFT)->default(0);
         $table->unsignedBigInteger(self::RGT)->default(0);
         $table->unsignedBigInteger(self::PARENT_ID)->nullable();
 
         $table->index(static::getDefaultColumns());
-        $table->foreign(self::PARENT_ID)->references($id)->on($table->getTable())->onDelete('cascade');
+        $table->foreign(self::PARENT_ID)->references($idColumn)->on($table->getTable())->onDelete('cascade');
     }
 
     /**
@@ -55,6 +56,7 @@ class NestedSet
     {
         $columns = static::getDefaultColumns();
 
+        $table->dropForeign(self::PARENT_ID);
         $table->dropIndex($columns);
         $table->dropColumn($columns);
     }

--- a/src/NestedSetServiceProvider.php
+++ b/src/NestedSetServiceProvider.php
@@ -13,8 +13,8 @@ class NestedSetServiceProvider extends ServiceProvider
             NestedSet::columns($this, $idColumn);
         });
 
-        Blueprint::macro('dropNestedSet', function (string $idColumn = 'id') {
-            NestedSet::dropColumns($this, $idColumn);
+        Blueprint::macro('dropNestedSet', function () {
+            NestedSet::dropColumns($this);
         });
     }
 }

--- a/src/NestedSetServiceProvider.php
+++ b/src/NestedSetServiceProvider.php
@@ -9,12 +9,12 @@ class NestedSetServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        Blueprint::macro('nestedSet', function () {
-            NestedSet::columns($this);
+        Blueprint::macro('nestedSet', function (string $idColumn = 'id') {
+            NestedSet::columns($this, $idColumn);
         });
 
-        Blueprint::macro('dropNestedSet', function () {
-            NestedSet::dropColumns($this);
+        Blueprint::macro('dropNestedSet', function (string $idColumn = 'id') {
+            NestedSet::dropColumns($this, $idColumn);
         });
     }
 }


### PR DESCRIPTION
This pull request targets to two code improvements:
1) According to latest Laravel release increment columns are now by default big integer. Thus ```static::PARENT_ID``` and ```static::LFT``` - ```static::RGT``` columns should also be set to ```unsignedBigInteger``` by default.
2) Also, for better resulting db scheme parent id should be constrained with a foreign key constraint. This pull request add a foreign key constraint from ```static::PARENT_ID```  column to ```$idColumn = 'id'``` which is passed as an optional parameter to ```nestedSet()``` macro function.