### PR TITLE
Use caret in Laravel 6 version name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
 
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "~5.7.0|~5.8.0|~6.0",
-        "illuminate/database": "~5.7.0|~5.8.0|~6.0",
-        "illuminate/events": "~5.7.0|~5.8.0|~6.0"
+        "illuminate/support": "~5.7.0|~5.8.0|^6.0",
+        "illuminate/database": "~5.7.0|~5.8.0|^6.0",
+        "illuminate/events": "~5.7.0|~5.8.0|^6.0"
     },
 
     "autoload": {


### PR DESCRIPTION
We need to use caret in Laravel 6 version name because from now it will use Semantic Versioning.
There will be no breaking changes in between 6.0 -> 6.1 -> 6.2 -> ...

Composer has a tricky behavior. It handles tilde constraint differently from SemVer specification.
In composer `~6.0` will translate to `>=6.0.0 <7.0.0` instead of `>=6.0.0 <6.1.0`.

It's not a bug, but its more common to use `^6.0` to show that package follows SemVer.