### PR TITLE
Modified assertNodeExists to perform null check

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -1179,7 +1179,7 @@ trait NodeTrait
     protected function assertNodeExists(self $node)
     {
         if ( is_null($node->getLft()) || is_null($node->getRgt()) ) {
-            throw new LogicException('Node must exists.');
+            throw new LogicException('Node must exist.');
         }
 
         return $this;

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -1178,7 +1178,7 @@ trait NodeTrait
      */
     protected function assertNodeExists(self $node)
     {
-        if ( ! $node->getLft() || ! $node->getRgt()) {
+        if ( is_null($node->getLft()) || is_null($node->getRgt()) ) {
             throw new LogicException('Node must exists.');
         }
 

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -677,7 +677,7 @@ trait NodeTrait
             ? $this->withTrashed()
             : $this->newQuery();
 
-        return $this->applyNestedSetScope($builder, $table);
+        return $this->applyNestedSetScope($builder->withoutGlobalScopes(), $table);
     }
 
     /**
@@ -687,7 +687,7 @@ trait NodeTrait
      */
     public function newScopedQuery($table = null)
     {
-        return $this->applyNestedSetScope($this->newQuery(), $table);
+        return $this->applyNestedSetScope($this->newQueryWithoutScopes(), $table);
     }
 
     /**

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -96,7 +96,7 @@ class QueryBuilder extends Builder
             $id = $id->getKey();
         } else {
             $valueQuery = $this->model
-                ->newQuery()
+                ->newQueryWithoutScopes()
                 ->toBase()
                 ->select("_.".$this->model->getRgtName())
                 ->from($this->model->getTable().' as _')
@@ -322,7 +322,7 @@ class QueryBuilder extends Builder
             $this->query->addBinding($id->getLft());
         } else {
             $valueQuery = $this->model
-                ->newQuery()
+                ->newQueryWithoutScopes()
                 ->toBase()
                 ->select('_n.'.$this->model->getLftName())
                 ->from($this->model->getTable().' as _n')
@@ -683,7 +683,7 @@ class QueryBuilder extends Builder
         // Check for nodes that have missing parent
         $checks['missing_parent' ] = $this->getMissingParentQuery();
 
-        $query = $this->query->newQuery();
+        $query = $this->query->newQueryWithoutScopes();
 
         foreach ($checks as $key => $inner) {
             $inner->selectRaw('count(1)');


### PR DESCRIPTION
I've suddenly started running into issues where the root folder (which now has an _lft value of 0, and an _rgt value of 0) forces the `assertNodeExists` method within `NodeTrait` check to fail.

To better perform this test, we should check if the value returned from the models attribute is null as this is the value returned if the node doesn't exist.

The previous compiled test was running as - 

```php
if ( ! $node->getLft() || ! $node->getRgt()) { // if ( ! 0 || ! 0 )
  throw new LogicException('Node must exists.');
}
```

So I was ending up with a `Node must exists.` exception. Whereas `$node->getLft()` and `$node->getRgt()` actually return null if the values cannot be found. So I think a better check would be - 

```php
if ( is_null($node->getLft()) || is_null($node->getRgt()) ) {
  throw new LogicException('Node must exists.');
}
```

I hope you'll consider this as a valid fix!
