### PR TITLE
[Need Review & Test] Can create tree with items from different levels

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -64,7 +64,7 @@ class Collection extends BaseCollection
 
         /** @var Model|NodeTrait $node */
         foreach ($this->items as $node) {
-            if ($node->getParentId() == $root) {
+            if ($node->getParentId() == $root || ! $node->getParentId()) {
                 $items[] = $node;
             }
         }


### PR DESCRIPTION
**Phenomenon**

With below data structure, if I use `toTree`, the items indexed with `2` will be eliminated from the result.

```
$categories = [
  0 => [ "id" => 10068, "parent_id" => 1, "name" => "A"],
  1 => [ "id" => 10085, "parent_id" => 10068, "name" => "B" ],
  2 => [ "id" => 10081, "parent_id" => null, "name" => "D" ]
]
```

**Solution needs to be reviewed**

The conditional statement modified to include the nodes (ROOT) has no parent.

```
/** @var Model|NodeTrait $node */
foreach ($this->items as $node) {
    if ($node->getParentId() == $root || ! $node->getParentId()) {
       $items[] = $node;
    }
}
```


