### PR TITLE
Add selectable extraColumns to fixTree method

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -844,17 +844,17 @@ class QueryBuilder extends Builder
      * Nodes with invalid parent are saved as roots.
      *
      * @param null|NodeTrait|Model $root
-     *
+     * @param array $extra
      * @return int The number of changed nodes
      */
-    public function fixTree($root = null)
+    public function fixTree($root = null, array $extraColumns = [])
     {
         $columns = [
             $this->model->getKeyName(),
             $this->model->getParentIdName(),
             $this->model->getLftName(),
             $this->model->getRgtName(),
-        ];
+        ] + $extraColumns;
 
         $dictionary = $this->model
             ->newNestedSetQuery()

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -844,17 +844,17 @@ class QueryBuilder extends Builder
      * Nodes with invalid parent are saved as roots.
      *
      * @param null|NodeTrait|Model $root
-     * @param array $extra
+     * @param array $extraColumns
      * @return int The number of changed nodes
      */
     public function fixTree($root = null, array $extraColumns = [])
     {
-        $columns = [
+        $columns = array_merge([
             $this->model->getKeyName(),
             $this->model->getParentIdName(),
             $this->model->getLftName(),
             $this->model->getRgtName(),
-        ] + $extraColumns;
+        ], $extraColumns);
 
         $dictionary = $this->model
             ->newNestedSetQuery()


### PR DESCRIPTION
This allows fixTree method select extra columns for model that require extra keys (for example cache key or cloud key) to work properly.



What happens:
In QueryBuilder:fixTree() method there is a section where the code is choosing  the "to be selected" columns. This line raises an issue for us since our Entity requires an extra column to be selected or else the fix tree will fail when trying to load nodes in the next lines.

```php
 public function fixTree($root = null)
    {
        $columns = [
            $this->model->getKeyName(),
            $this->model->getParentIdName(),
            $this->model->getLftName(),
            $this->model->getRgtName(),
            'cloud_id', // <--- our model needs this  cloud id to be properly loaded in case of passive caching
        ];
```

Expected Behavior:
The solution is rather simple. Just allow selecting extra columns as optional. No extra change is needed:

Here is the solution:

```php
    public function fixTree($root = null, array $extra = [])
    {
        $columns = [
            $this->model->getKeyName(),
            $this->model->getParentIdName(),
            $this->model->getLftName(),
            $this->model->getRgtName(),
        ] // add  $extra to it;
```

This would solve our issue and possibly any other code that has multiple clouds. 


https://github.com/lazychaser/laravel-nestedset/issues/501