### PR TITLE
Rename getRelationQuery in BaseRelation due to conflict in Laravel 8.44

### DIFF
--- a/src/BaseRelation.php
+++ b/src/BaseRelation.php
@@ -118,7 +118,7 @@ abstract class BaseRelation extends Relation
      *
      * @return mixed
      */
-    public function getRelationQuery(
+    public function getRelationshipQuery(
         EloquentBuilder $query, EloquentBuilder $parent,
         $columns = [ '*' ]
     ) {


### PR DESCRIPTION
With `oneOfMany()` feature brought into Laravel (starting 8.44) a method `Relation::getRelationQuery()` was added to the `Illuminate\Database\Eloquent\Relations\Relation`.
Since BaseRelation extends this class the signature on the classes now mismatches throwing an error when trying to use this class.

This PR changes the name of the method to resolve the conflict. 

This method is not used internally in the library and is not covered by tests so no other changes are required for this (all tests pass). However this being a public method creates an exposure for external conflicts.