### PR TITLE
Fix lazy loaded collection

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -8,6 +8,26 @@ use Illuminate\Database\Eloquent\Model;
 class Collection extends BaseCollection
 {
     /**
+     * Flatten a tree into a non recursive array.
+     *
+     * @return $this
+     */
+    public function flattenTreeDeep() 
+    {
+        $result = collect();
+        
+        foreach ($this->items as $item) {
+            $result->push($item);
+
+            if ($item->children instanceof self) {
+                $result = $result->merge($item->children->flattenTreeDeep());
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Fill `parent` and `children` relationships for every node in the collection.
      *
      * This will overwrite any previously set relations.
@@ -18,7 +38,8 @@ class Collection extends BaseCollection
     {
         if ($this->isEmpty()) return $this;
 
-        $groupedNodes = $this->groupBy($this->first()->getParentIdName());
+        $groupedNodes = $this->flattenTreeDeep()
+            ->groupBy($this->first()->getParentIdName());
 
         /** @var NodeTrait|Model $node */
         foreach ($this->items as $node) {
@@ -139,5 +160,4 @@ class Collection extends BaseCollection
 
         return $this;
     }
-
 }


### PR DESCRIPTION
When Building a tree based on lazy loaded items.

`$tree = Category::with('children')->get()->toTree();`

children attribute is null after being processed inside `linkNodes()` methods. 
This is because of group by parent_id.

The solution i found is to flatten the whole relation. then group by as normally done.