### PR TITLE
FIX: Issues with Laravel Novas reverse dependency resolving

### DIFF
--- a/src/BaseRelation.php
+++ b/src/BaseRelation.php
@@ -195,4 +195,16 @@ abstract class BaseRelation extends Relation
 
         return $result;
     }
+
+    /**
+     * Get the plain foreign key.
+     *
+     * @return mixed
+     */
+    public function getForeignKeyName()
+    {
+        // Return a stub value for relation
+        // resolvers which need this function.
+        return NestedSet::PARENT_ID;
+    }
 }


### PR DESCRIPTION
Nova complains about the absence of the getForeignKeyName() method when it tries to resolve multi-level reverse relations.

After adding dummy methods to both Ascending- and DescendingRelations it started to work fine. 

I did not notice any side effects, tests remained green.