### PR TITLE
Fixed Undefined Key error in nested relationship

### DIFF
--- a/src/BaseRelation.php
+++ b/src/BaseRelation.php
@@ -158,7 +158,7 @@ abstract class BaseRelation extends Relation
         // The first model in the array is always the parent, so add the scope constraints based on that model.
         // @link https://github.com/laravel/framework/pull/25240
         // @link https://github.com/lazychaser/laravel-nestedset/issues/351
-        optional($models[0])->applyNestedSetScope($this->query);
+        optional(reset($models))->applyNestedSetScope($this->query);
 
         $this->query->whereNested(function (Builder $inner) use ($models) {
             // We will use this query in order to apply constraints to the


### PR DESCRIPTION
Hello there

When using nested, optional relationships (which might be quite an edge case) there is a small possibility that the library is throwing an error.

It is correctly described in the comment above the problematic line, that `The first model in the array is always the parent`. This can be retrieved in most cases by index `0`. 

BUT, if the previously called filter in [Illuminate/Database/Eloquent/Collection.php:227](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Eloquent/Collection.php#L227) happens to filter the model with index `0` (which is perfectly possible, as otherwise the filter would be unnecessary), then we have an `Undefined array key 0` error.

Therefore, I propose to change the given implementation to use `reset()` to get the first model, as this truly returns the first model in the array rather than the model with index 0.