### PR TITLE
Fix return type of NodeTrait::scoped method

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -725,7 +725,7 @@ trait NodeTrait
     /**
      * @param array $attributes
      *
-     * @return self
+     * @return QueryBuilder
      */
     public static function scoped(array $attributes)
     {


### PR DESCRIPTION
This PR updates the return type hint of the `scoped` method in the NodeTrait. This avoids confusion by IDEs and static analysis tools.