### PR TITLE
[6.x] support Laravel 10.x

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@
 
 This is a Laravel 4-8 package for working with trees in relational databases.
 
-*   **Laravel 8.0** is supported since v6
+*   **Laravel 8.0, 9.0, 10.0** is supported since v6
 *   **Laravel 5.7, 5.8, 6.0, 7.0** is supported since v5
 *   **Laravel 5.5, 5.6** is supported since v4.3
 *   **Laravel 5.2, 5.3, 5.4** is supported since v4

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
 
     "require": {
         "php": "^7.2.5|^8.0",
-        "illuminate/support": "^7.0|^8.0|^9.0",
-        "illuminate/database": "^7.0|^8.0|^9.0",
-        "illuminate/events": "^7.0|^8.0|^9.0"
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/events": "^7.0|^8.0|^9.0|^10.0"
     },
 
     "autoload": {


### PR DESCRIPTION
This targets the 6.x branch, rather than 5.x, hence more relevant/useful than the @laravel-shift auto-generated PR.

@lazychaser Hope you can merge this soon and tag a new 6.x branch release..