### PR TITLE
Fix issue with Node::fixTree

### DIFF
--- a/src/NestedSet.php
+++ b/src/NestedSet.php
@@ -40,7 +40,7 @@ class NestedSet
     {
         $table->unsignedInteger(self::LFT)->default(0);
         $table->unsignedInteger(self::RGT)->default(0);
-        $table->unsignedInteger(self::PARENT_ID)->nullable();
+        $table->unsignedInteger(self::PARENT_ID)->default(0);
 
         $table->index(static::getDefaultColumns());
     }


### PR DESCRIPTION
When we created new Node with parent_id = 0 it stored to database with parent_id = null. So if we have nodes with parent_id = null then Node::fixTree() working incorrect, because null != 0 and _lft and _rgt don't right fixed