### PR TITLE
Bugfix in QueryBuilder::columnPatch

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -654,7 +654,7 @@ class QueryBuilder extends Builder
         extract($params);
 
         /** @var int $height */
-        if ($height > 0) $height = '+'.$height;
+        if ($height >= 0) $height = '+'.$height;
 
         if (isset($cut)) {
             return new Expression("case when {$col} >= {$cut} then {$col}{$height} else {$col} end");
@@ -665,7 +665,7 @@ class QueryBuilder extends Builder
         /** @var int $rgt */
         /** @var int $from */
         /** @var int $to */
-        if ($distance > 0) $distance = '+'.$distance;
+        if ($distance >= 0) $distance = '+'.$distance;
 
         return new Expression("case ".
                               "when {$col} between {$lft} and {$rgt} then {$col}{$distance} ". // Move the node


### PR DESCRIPTION
When we have $height === 0 or $distance === 0, QueryBuilder::columnPatch builds SQL expressions like 'when "_rgt" between 12483 and 12496 then **"_rgt"0** else "_rgt" end' AND sql server fails at "_rgt"0.

Correct behavior is "_rgt" + 0 in that case

Bugfix for #587 