### PR TITLE
Add `getQualifiedForeignKeyName` Method for Foreign Key Relation

### DIFF
--- a/src/BaseRelation.php
+++ b/src/BaseRelation.php
@@ -202,4 +202,16 @@ abstract class BaseRelation extends Relation
         // resolvers which need this function.
         return NestedSet::PARENT_ID;
     }
+
+     /**
+     * Get the Qualify plain foreign key.
+     *
+     * @return mixed
+     */
+    public function getQualifiedForeignKeyName()
+    {
+        // Return a stub value for relation
+        // resolvers which need this function.
+        return NestedSet::PARENT_ID;
+    }
 }


### PR DESCRIPTION
Hi, 

In this pull request, I have added the missing method `getQualifiedForeignKeyName` to handle relationships. This method is essential for packages like `rebing/graphql-laravel` that use it to retrieve the parent foreign key column name.
