### PR TITLE
fix: resolve nested booting issue in NodeTrait::usesSoftDelete

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -110,9 +110,10 @@ trait NodeTrait
         static $softDelete;
 
         if (is_null($softDelete)) {
-            $instance = new static;
-
-            return $softDelete = method_exists($instance, 'bootSoftDeletes');
+            $softDelete = in_array(
+                \Illuminate\Database\Eloquent\SoftDeletes::class,
+                class_uses_recursive(static::class)
+            );
         }
 
         return $softDelete;


### PR DESCRIPTION
Laravel 13 prevents nested model instantiation during the boot cycle, see: https://laravel.com/docs/13.x/upgrade#model-booting-and-nested-instantiation

The previous implementation of usesSoftDelete() relied on `new static`, which caused a recursive boot process and triggered:

```
LogicException: Model::bootIfNotBooted may not be called while booting
```

Refactored the method to detect SoftDeletes usage via class_uses_recursive() instead of instantiating the model. This change removes the boot-time side effect and aligns the package with Laravel 13 model booting constraints.

This is solved my issue: #638

Thank you