### PR TITLE
Laravel 13 introduced a guard that throws a `LogicException` if `boot…

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -43,28 +43,32 @@ trait NodeTrait
      */
     public static function bootNodeTrait()
     {
-        static::saving(function ($model) {
-            return $model->callPendingAction();
-        });
+        static::whenBooted(function () {
 
-        static::deleting(function ($model) {
-            // We will need fresh data to delete node safely
-            $model->refreshNode();
-        });
-
-        static::deleted(function ($model) {
-            $model->deleteDescendants();
-        });
-
-        if (static::usesSoftDelete()) {
-            static::restoring(function ($model) {
-                static::$deletedAt = $model->{$model->getDeletedAtColumn()};
+            static::saving(function ($model) {
+                return $model->callPendingAction();
             });
 
-            static::restored(function ($model) {
-                $model->restoreDescendants(static::$deletedAt);
+            static::deleting(function ($model) {
+                // We will need fresh data to delete node safely
+                $model->refreshNode();
             });
-        }
+
+            static::deleted(function ($model) {
+                $model->deleteDescendants();
+            });
+
+            if (static::usesSoftDelete()) {
+                static::restoring(function ($model) {
+                    static::$deletedAt = $model->{$model->getDeletedAtColumn()};
+                });
+
+                static::restored(function ($model) {
+                    $model->restoreDescendants(static::$deletedAt);
+                });
+            }
+            
+        });
     }
 
     /**


### PR DESCRIPTION

This occurred because `NodeTrait` had two issues that caused nested instantiation during the boot cycle.

(https://github.com/lazychaser/laravel-nestedset/issues/638)

## Changes

### 1. Wrap event listeners in `static::whenBooted()`

All model event registrations (`saving`, `deleting`, `deleted`, `restoring`, `restored`) inside `bootNodeTrait()` are now deferred inside `static::whenBooted()`. This ensures they are only registered **after** the model has finished booting, preventing any mid-boot side effects.

### 2. Refactor `usesSoftDelete()` to avoid model instantiation

The previous implementation triggered a nested boot cycle by instantiating the model (`new static`) to detect soft delete usage. Replaced with `class_uses_recursive(static::class)`, which inspects the class via reflection without instantiation:

```php
// Before — caused nested boot → LogicException in Laravel 13
$softDelete = in_array(..., class_uses_recursive(new static));

// After — safe, no instantiation
$softDelete = in_array(
    \Illuminate\Database\Eloquent\SoftDeletes::class,
    class_uses_recursive(static::class)
);
```

References
- Laravel 13 upgrade guide: [Model Booting and Nested Instantiation](https://laravel.com/docs/13.x/upgrade#model-booting-and-nested-instantiation)
- Related Laravel framework issue: laravel/framework#59260