### PR TITLE
Require Laravel >= 12.0, as whenBooted() only exists in 12.x upwards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": ">=7.0",
-        "illuminate/database": ">=7.0",
-        "illuminate/events": ">=7.0"
+        "illuminate/support": ">=12.0",
+        "illuminate/database": ">=12.0",
+        "illuminate/events": ">=12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": ">=12.0",
-        "illuminate/database": ">=12.0",
-        "illuminate/events": ">=12.0"
+        "illuminate/support": ">=12.8",
+        "illuminate/database": ">=12.8",
+        "illuminate/events": ">=12.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
See https://github.com/lazychaser/laravel-nestedset/issues/641