### PR TITLE
Revert whenBooted() and Laravel version constraint bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": ">=7.0",
-        "illuminate/database": ">=7.0",
-        "illuminate/events": ">=7.0"
+        "illuminate/support": ">=12.0",
+        "illuminate/database": ">=12.0",
+        "illuminate/events": ">=12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": ">=12.0",
-        "illuminate/database": ">=12.0",
-        "illuminate/events": ">=12.0"
+        "illuminate/support": ">=7.0",
+        "illuminate/database": ">=7.0",
+        "illuminate/events": ">=7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": ">=12.8",
-        "illuminate/database": ">=12.8",
-        "illuminate/events": ">=12.8"
+        "illuminate/support": ">=12.0",
+        "illuminate/database": ">=12.0",
+        "illuminate/events": ">=12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": ">=12.0",
-        "illuminate/database": ">=12.0",
-        "illuminate/events": ">=12.0"
+        "illuminate/support": ">=12.8",
+        "illuminate/database": ">=12.8",
+        "illuminate/events": ">=12.8"
     },
     "autoload": {
         "psr-4": {

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -43,32 +43,28 @@ trait NodeTrait
      */
     public static function bootNodeTrait()
     {
-        static::whenBooted(function () {
-
-            static::saving(function ($model) {
-                return $model->callPendingAction();
-            });
-
-            static::deleting(function ($model) {
-                // We will need fresh data to delete node safely
-                $model->refreshNode();
-            });
-
-            static::deleted(function ($model) {
-                $model->deleteDescendants();
-            });
-
-            if (static::usesSoftDelete()) {
-                static::restoring(function ($model) {
-                    static::$deletedAt = $model->{$model->getDeletedAtColumn()};
-                });
-
-                static::restored(function ($model) {
-                    $model->restoreDescendants(static::$deletedAt);
-                });
-            }
-            
+        static::saving(function ($model) {
+            return $model->callPendingAction();
         });
+
+        static::deleting(function ($model) {
+            // We will need fresh data to delete node safely
+            $model->refreshNode();
+        });
+
+        static::deleted(function ($model) {
+            $model->deleteDescendants();
+        });
+
+        if (static::usesSoftDelete()) {
+            static::restoring(function ($model) {
+                static::$deletedAt = $model->{$model->getDeletedAtColumn()};
+            });
+
+            static::restored(function ($model) {
+                $model->restoreDescendants(static::$deletedAt);
+            });
+        }
     }
 
     /**

--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use LogicException;
 
@@ -111,7 +112,7 @@ trait NodeTrait
 
         if (is_null($softDelete)) {
             $softDelete = in_array(
-                \Illuminate\Database\Eloquent\SoftDeletes::class,
+                SoftDeletes::class,
                 class_uses_recursive(static::class)
             );
         }


### PR DESCRIPTION
We don't need whenBooted(), as usesSoftDelete() now uses class_uses_recursive() - therefore, there's no LogicException any more during booting. Therefore we can still support laravel/framework all the way back to 7.x.